### PR TITLE
Adds fix when creating conversation with skype for business

### DIFF
--- a/microsoftbotframework/conversationoperations.py
+++ b/microsoftbotframework/conversationoperations.py
@@ -1,4 +1,4 @@
-gfrom .activity import Activity
+from .activity import Activity
 
 
 class ReplyToActivity(Activity):

--- a/microsoftbotframework/conversationoperations.py
+++ b/microsoftbotframework/conversationoperations.py
@@ -76,7 +76,7 @@ class CreateConversation(Activity):
         self.channelId = None
         self.conversation = None
 
-        response_json = {
+        request_json = {
             'bot': self.fromAccount if self.bot is None else self.bot,
             'isGroup': False if self.isGroup is None else self.isGroup,
             'members': [self.recipient] if self.members is None else self.members,
@@ -92,16 +92,19 @@ class CreateConversation(Activity):
 
         response_url = self.urljoin(self.serviceUrl, "/v3/conversations")
 
-        response = self._request(response_url, 'post', response_json)
+        response = self._request(response_url, 'post', request_json)
 
-        # skype for business is not returning the id of the newly created
-        # conversation. Only save the response if the id exists
-        if 'id' in response.json():
-            self.save_response('CreateConversation',
-                               response.json()['id'],
-                               response_json,
-                               {},
-                               response.json())
+        # Skype for Business returns the key 'Id', not 'id', fix the dict to
+        # change 'Id' to 'id'
+        response_json = response.json()
+        if 'Id' in response_json and 'id' not in response_json:
+            response_json['id'] = response_json['Id']
+            del response_json['Id']
+        self.save_response('CreateConversation',
+                           response_json['id'],
+                           request_json,
+                           {},
+                           response_json)
         return response
 
 

--- a/microsoftbotframework/conversationoperations.py
+++ b/microsoftbotframework/conversationoperations.py
@@ -94,12 +94,13 @@ class CreateConversation(Activity):
 
         response = self._request(response_url, 'post', request_json)
 
-        # Skype for Business returns the key 'Id', not 'id', fix the dict to
-        # change 'Id' to 'id'
+        # Skype for Business returns the key 'Id', not 'id', fix the response
+        # by changing 'Id' to 'id'
         response_json = response.json()
         if 'Id' in response_json and 'id' not in response_json:
-            response_json['id'] = response_json['Id']
-            del response_json['Id']
+            response._content = response._content.replace(b"\"id\":",
+                                                          b"\"Id\":")
+        response_json = response.json()
         self.save_response('CreateConversation',
                            response_json['id'],
                            request_json,

--- a/microsoftbotframework/conversationoperations.py
+++ b/microsoftbotframework/conversationoperations.py
@@ -98,8 +98,8 @@ class CreateConversation(Activity):
         # by changing 'Id' to 'id'
         response_json = response.json()
         if 'Id' in response_json and 'id' not in response_json:
-            response._content = response._content.replace(b"\"id\":",
-                                                          b"\"Id\":")
+            response._content = response._content.replace(b"\"Id\":",
+                                                          b"\"id\":")
         response_json = response.json()
         self.save_response('CreateConversation',
                            response_json['id'],

--- a/microsoftbotframework/conversationoperations.py
+++ b/microsoftbotframework/conversationoperations.py
@@ -94,11 +94,14 @@ class CreateConversation(Activity):
 
         response = self._request(response_url, 'post', response_json)
 
-        self.save_response('CreateConversation',
-                           response.json()['id'],
-                           response_json,
-                           {},
-                           response.json())
+        # skype for business is not returning the id of the newly created
+        # conversation. Only save the response if the id exists
+        if 'id' in response.json():
+            self.save_response('CreateConversation',
+                               response.json()['id'],
+                               response_json,
+                               {},
+                               response.json())
         return response
 
 

--- a/microsoftbotframework/conversationoperations.py
+++ b/microsoftbotframework/conversationoperations.py
@@ -1,4 +1,4 @@
-from .activity import Activity
+gfrom .activity import Activity
 
 
 class ReplyToActivity(Activity):
@@ -84,11 +84,11 @@ class CreateConversation(Activity):
             'self': self.to_dict(),
         }
 
-        if len(response_json['members']) > 1:
-            response_json['isGroup'] = True
+        if len(request_json['members']) > 1:
+            request_json['isGroup'] = True
 
         if self.topicName is not None:
-            response_json['topicName'] = self.topicName
+            request_json['topicName'] = self.topicName
 
         response_url = self.urljoin(self.serviceUrl, "/v3/conversations")
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name='microsoftbotframework',
-      version='0.3.0',
+      version='0.3.1',
       description='A wrapper for the microsoft bot framework API',
       classifiers=[
             'Development Status :: 3 - Alpha',


### PR DESCRIPTION
- Problem: Skype For business does not return the id of the new conversation, just the 'Id' so a key error was thrown when one attempted to access response.json()['id']
- Solution: edit the response to change the kay from 'Id' to 'id'
